### PR TITLE
Use black background for loading screen

### DIFF
--- a/loader.css
+++ b/loader.css
@@ -7,11 +7,11 @@ body.loading{overflow:hidden}
   display:flex;
   justify-content:center;
   align-items:center;
-  background:white;
+  background:black;
   z-index:9999;
 }
 #loader .container{
-  background:white;
+  background:black;
   width:90vmin;
   height:90vmin;
   position:relative;


### PR DESCRIPTION
## Summary
- set loader overlay and container backgrounds to black for full-screen dark loader

## Testing
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_b_6898d9796e208321bdb85e52b8cc462f